### PR TITLE
Official macOS support (Mega Man X)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Build artifacts
 build/
+build-mac/
+# macOS/Linux runtime ROM-path cache + sibling-repo symlink
+rom.cfg
+/snesrecomp
 *.obj
 *.pdb
 *.ilk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.16)
+project(MegaManXSNESRecomp C)
+
+# Cross-platform (macOS/Linux) build for MegaManXSNESRecomp.
+#
+# The canonical Windows build is the MSVC solution (mmx.sln). This CMake build
+# mirrors the same source list (see snesrecomp/runner/runner.cmake) so the game
+# builds natively on macOS/Linux with clang/gcc + SDL2 + OpenGL.
+#
+# Prerequisites: a snesrecomp checkout at ./snesrecomp (symlink/clone of the
+# sibling repo), the generated C in src/gen/ (run `bash tools/regen.sh` with a
+# verified mmx.sfc at the repo root), SDL2 (e.g. `brew install sdl2`).
+
+set(CMAKE_C_STANDARD 11)
+
+set(SNESRECOMP_ROOT ${CMAKE_SOURCE_DIR}/snesrecomp)
+include(${SNESRECOMP_ROOT}/runner/runner.cmake)
+
+find_package(SDL2 REQUIRED)
+find_package(OpenGL REQUIRED)
+
+# Generated recompiler output (produced by tools/regen.sh; not committed).
+file(GLOB MMX_GEN_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/gen/*.c)
+if(NOT MMX_GEN_SOURCES)
+    message(FATAL_ERROR
+        "src/gen/ is empty — run `bash tools/regen.sh` with a verified mmx.sfc "
+        "at the repo root before building.")
+endif()
+
+add_executable(MegaManXSNESRecomp
+    ${SNESRECOMP_RUNNER_SOURCES}
+    # game-specific runtime
+    src/config.c
+    src/glsl_shader.c
+    src/main.c
+    src/post_mortem.c
+    src/opengl.c
+    src/mmx_00.c
+    src/gen_stubs.c
+    src/mmx_cpu_infra.c
+    src/mmx_rtl.c
+    src/mmx_spc_player.c
+    src/fiber_compat.c    # Win32 Fiber API shim (ucontext) for non-Windows
+
+    # OpenGL function loader
+    third_party/gl_core/gl_core_3_1.c
+    # recompiled banks (generated)
+    ${MMX_GEN_SOURCES}
+)
+
+target_include_directories(MegaManXSNESRecomp PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/recomp
+    ${SNESRECOMP_RUNNER_INCLUDE_DIRS}
+    ${SDL2_INCLUDE_DIRS}
+)
+
+target_compile_definitions(MegaManXSNESRecomp PRIVATE
+    SMW_DISABLE_LM=1
+    SYSTEM_VOLUME_MIXER_AVAILABLE=0   # Win32 WASAPI volume control excluded
+    SNESRECOMP_TRACE=0                # no TCP debug server (debug_server.c excluded)
+    SNESRECOMP_REVERSE_DEBUG=0        # raw WRAM stores; matches non-debug generated C
+)
+
+# The recompiled C is machine-generated; quiet its warnings and tolerate the
+# K&R-style implicit declarations clang rejects by default.
+if(NOT MSVC)
+    target_compile_options(MegaManXSNESRecomp PRIVATE
+        -w -Wno-implicit-function-declaration)
+endif()
+
+target_link_libraries(MegaManXSNESRecomp PRIVATE
+    ${SDL2_LIBRARIES}
+    OpenGL::GL
+)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ Build:
 msbuild mmx.sln /p:Configuration=Oracle /p:Platform=x64 /m
 ```
 
+### macOS / Linux (CMake)
+
+Builds natively on macOS (Apple Silicon + Intel) and Linux with clang/gcc.
+Prerequisites: CMake 3.16+, SDL2, Ninja, Python 3.9+
+(`brew install cmake sdl2 ninja python3`).
+
+```bash
+ln -s ../snesrecomp snesrecomp     # sibling framework checkout (see above)
+bash tools/regen.sh --no-tests     # generate src/gen/ (needs a verified mmx.sfc at repo root)
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+cmake --build build
+./build/MegaManXSNESRecomp         # first run prompts for / caches the ROM path in rom.cfg
+```
+
+`Alt+Enter` toggles fullscreen and SDL game controllers work out of the box
+(see Controls above). The emulator oracle is a developer-only feature and is
+off in this build.
+
 The recompiled C in `src/gen/` is **not** committed — contributors must
 regenerate it from a local ROM before the first build. See the next
 section.
@@ -119,9 +137,11 @@ section.
 
 1. Drop a legally-obtained `mmx.sfc` at the repo root (`.gitignore`
    excludes it).
-2. Run:
+2. Run `bash tools/regen.sh --no-tests` (drives the recompiler over every
+   `recomp/bank*.cfg` and writes `src/gen/bankXX_v2.c` + `dispatch_v2.c`).
+   On Windows without bash, invoke the underlying tool directly:
    ```bash
-   python ../snesrecomp/tools/v2_regen.py --rom mmx.sfc --cfg-dir recomp --out-dir src/gen --prefix mmx
+   python snesrecomp/tools/v2_regen.py --rom mmx.sfc --cfg-dir recomp --out-dir src/gen
    ```
 3. Rebuild as above.
 

--- a/src/fiber_compat.c
+++ b/src/fiber_compat.c
@@ -1,0 +1,76 @@
+/*
+ * fiber_compat.c — POSIX (ucontext) implementation of the Win32 Fiber API
+ * used by the MMX task scheduler. See fiber_compat.h. Compiled to nothing on
+ * Windows, where the native Fiber API is used directly.
+ */
+#ifndef _WIN32
+#define _XOPEN_SOURCE 600   /* expose ucontext on macOS/glibc — must precede includes */
+
+#include "fiber_compat.h"
+#include <ucontext.h>
+#include <stdlib.h>
+
+typedef struct Fiber {
+    ucontext_t ctx;
+    FiberProc  entry;
+    void      *param;
+    void      *stack;     /* NULL for a ConvertThreadToFiber handle */
+} Fiber;
+
+/* The fiber currently executing on this thread. Updated by SwitchToFiber
+ * before the context swap, so a freshly-started fiber's trampoline sees
+ * itself here. */
+static Fiber *g_current_fiber = NULL;
+
+static void fiber_trampoline(void) {
+    Fiber *self = g_current_fiber;
+    if (self && self->entry)
+        self->entry(self->param);
+    /* MMX fiber entries never fall off the end (they loop SwitchToFiber back
+     * to the scheduler). If one ever does, there is no safe continuation. */
+    abort();
+}
+
+void *ConvertThreadToFiber(void *param) {
+    (void)param;
+    Fiber *f = (Fiber *)calloc(1, sizeof(Fiber));
+    if (!f) return NULL;
+    /* No stack of its own — it rides the thread's existing stack. The ctx is
+     * populated by the first swapcontext that switches away from it. */
+    g_current_fiber = f;
+    return f;
+}
+
+void *CreateFiber(size_t stack_size, FiberProc entry, void *param) {
+    Fiber *f = (Fiber *)calloc(1, sizeof(Fiber));
+    if (!f) return NULL;
+    f->stack = malloc(stack_size);
+    if (!f->stack) { free(f); return NULL; }
+    f->entry = entry;
+    f->param = param;
+    if (getcontext(&f->ctx) != 0) { free(f->stack); free(f); return NULL; }
+    f->ctx.uc_stack.ss_sp   = f->stack;
+    f->ctx.uc_stack.ss_size = stack_size;
+    f->ctx.uc_link          = NULL;
+    makecontext(&f->ctx, fiber_trampoline, 0);
+    return f;
+}
+
+void SwitchToFiber(void *fiber) {
+    Fiber *target = (Fiber *)fiber;
+    if (!target || target == g_current_fiber) return;
+    Fiber *prev = g_current_fiber;
+    g_current_fiber = target;
+    swapcontext(&prev->ctx, &target->ctx);
+}
+
+void DeleteFiber(void *fiber) {
+    Fiber *f = (Fiber *)fiber;
+    if (!f) return;
+    free(f->stack);   /* free(NULL) is fine for thread-origin fibers */
+    free(f);
+}
+
+unsigned long GetLastError(void) { return 0; }
+
+#endif /* !_WIN32 */

--- a/src/fiber_compat.h
+++ b/src/fiber_compat.h
@@ -1,0 +1,38 @@
+#pragma once
+/*
+ * fiber_compat.h — cross-platform fiber API for the MMX cooperative task
+ * scheduler (mmx_rtl.c).
+ *
+ * The scheduler cooperatively switches between a "scheduler" fiber and one
+ * fiber per task slot, each with its own C stack so a task can yield mid-call
+ * and resume later. On Windows this is the native Fiber API. On POSIX there is
+ * no Fiber API, so we provide an equivalent backed by ucontext_t — same five
+ * entry points, same semantics — so mmx_rtl.c is identical on both platforms.
+ */
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <stddef.h>
+
+#  ifndef CALLBACK
+#    define CALLBACK   /* no calling-convention decoration on POSIX */
+#  endif
+
+typedef void (*FiberProc)(void *);
+
+/* Promote the current thread to a fiber; returns its handle (or NULL). */
+void *ConvertThreadToFiber(void *param);
+
+/* Create a fiber with its own stack that will run entry(param) when first
+ * switched to. Returns a handle (or NULL on failure). */
+void *CreateFiber(size_t stack_size, FiberProc entry, void *param);
+
+/* Cooperatively switch execution to the given fiber. */
+void  SwitchToFiber(void *fiber);
+
+/* Free a fiber created by CreateFiber. */
+void  DeleteFiber(void *fiber);
+
+/* Win32 parity for the scheduler's error logging; always 0 on POSIX. */
+unsigned long GetLastError(void);
+#endif

--- a/src/mmx.vcxproj
+++ b/src/mmx.vcxproj
@@ -252,16 +252,16 @@
     <ClCompile Include="platform\win32\volume_control.c" />
     <ClCompile Include="mmx_00.c" />
     <ClCompile Include="gen_stubs.c" />
-    <ClCompile Include="gen\mmx_00_v2.c" />
-    <ClCompile Include="gen\mmx_01_v2.c" />
-    <ClCompile Include="gen\mmx_02_v2.c" />
-    <ClCompile Include="gen\mmx_03_v2.c" />
-    <ClCompile Include="gen\mmx_04_v2.c" />
-    <ClCompile Include="gen\mmx_06_v2.c" />
-    <ClCompile Include="gen\mmx_07_v2.c" />
-    <ClCompile Include="gen\mmx_08_v2.c" />
+    <ClCompile Include="gen\bank00_v2.c" />
+    <ClCompile Include="gen\bank01_v2.c" />
+    <ClCompile Include="gen\bank02_v2.c" />
+    <ClCompile Include="gen\bank03_v2.c" />
+    <ClCompile Include="gen\bank04_v2.c" />
+    <ClCompile Include="gen\bank06_v2.c" />
+    <ClCompile Include="gen\bank07_v2.c" />
+    <ClCompile Include="gen\bank08_v2.c" />
     <ClCompile Include="gen\unresolved_stubs_v2.c" />
-    <ClCompile Include="gen\mmx_dispatch_v2.c" />
+    <ClCompile Include="gen\dispatch_v2.c" />
     <ClCompile Include="..\snesrecomp\runner\src\debug_server.c">
       <ExcludedFromBuild Condition="'$(Configuration)'=='Production'">true</ExcludedFromBuild>
     </ClCompile>

--- a/src/mmx_rtl.c
+++ b/src/mmx_rtl.c
@@ -9,8 +9,8 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <windows.h>
 #include <stdlib.h>
+#include "fiber_compat.h"   /* Win32 Fibers on Windows, ucontext shim on POSIX */
 
 /* C-host implementation of the MMX cooperative task scheduler at
  * $00:8099. Replaces the asm dispatch loop with a C function that:

--- a/tools/regen.sh
+++ b/tools/regen.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regen pipeline driver for MegaManXSNESRecomp.
+#
+# Regenerates src/gen/*.c from the recomp/bank_*.cfg configs over a verified
+# mmx.sfc, then syncs recomp/funcs.h. Mirrors SuperMarioWorldRecomp/tools/regen.sh.
+#
+# Flags:
+#   --no-tests   skip the framework test suite (default: run it).
+#   -h | --help  this message.
+#
+# Run from anywhere — paths resolve relative to this script's location.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RUN_TESTS=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-tests) RUN_TESTS=0 ;;
+    -h|--help)  sed -n '2,/^set -euo/p' "$0" | sed -n '/^# /p' | sed 's/^# //'; exit 0 ;;
+    *) echo "regen.sh: unknown flag: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+cd "$ROOT"
+
+ROM="mmx.sfc"
+TESTS="snesrecomp/tests/run_tests.py"
+
+# Python interpreter: prefer python3 (macOS / most Linux have no bare `python`).
+PYTHON="${PYTHON:-$(command -v python3 || command -v python || true)}"
+if [ -z "$PYTHON" ]; then
+  echo "regen.sh: no python3/python interpreter found on PATH" >&2
+  exit 1
+fi
+
+if [ ! -f "$ROM" ]; then
+  echo "regen.sh: $ROM not found at repo root — drop a verified MMX ROM there." >&2
+  exit 1
+fi
+
+step() { echo; echo "=== $* ==="; }
+
+step "Regenerating banks"
+"$PYTHON" snesrecomp/tools/v2_regen.py --rom "$ROM" \
+    --cfg-dir recomp --out-dir src/gen
+
+step "Syncing funcs.h"
+"$PYTHON" snesrecomp/tools/v2_sync_funcs_h.py --cfg-dir recomp \
+    --out recomp/funcs.h
+
+if [ "$RUN_TESTS" -eq 1 ]; then
+  step "Framework tests"
+  "$PYTHON" "$TESTS"
+fi
+
+step "Done"


### PR DESCRIPTION
Builds and runs **natively on macOS (Apple Silicon, arm64)** — verified booting to the intro/title via the recompiler against a CRC/SHA-verified MMX (USA) ROM. Pre-existing alpha glitches/lockups are platform-independent (same recompiled C as the Windows build).

## What's here
- **CMakeLists.txt** — native macOS/Linux build via `snesrecomp/runner/runner.cmake` + SDL2 + OpenGL. Mirrors `mmx.vcxproj`; excludes Win32 `volume_control.c`; sets `SYSTEM_VOLUME_MIXER_AVAILABLE=0`, `SNESRECOMP_TRACE=0`, `SNESRECOMP_REVERSE_DEBUG=0`.
- **src/fiber_compat.{h,c}** — portable Win32 **Fiber API** shim. The MMX task scheduler (`mmx_rtl.c`) uses Fibers (`CreateFiber`/`SwitchToFiber`/…); this provides the native API on Windows and a `ucontext`-backed equivalent on POSIX, so the scheduler is unchanged on both platforms. Replaces a bare `<windows.h>` include.
- **tools/regen.sh** — python3-safe regen driver.
- **mmx.vcxproj** — game-agnostic generated filenames (`bankXX_v2.c` / `dispatch_v2.c`).

## Build (macOS)
```bash
ln -s ../snesrecomp snesrecomp        # sibling framework checkout
bash tools/regen.sh --no-tests        # generate src/gen/ from a verified mmx.sfc at repo root
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
cmake --build build
```

## Depends on
snesrecomp `feature/macos-support` (runner.cmake + agnostic generated filenames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)